### PR TITLE
Refactoring `simulation_times` and `oscillatory_status`

### DIFF
--- a/src/BiologicalOscillations.jl
+++ b/src/BiologicalOscillations.jl
@@ -7,16 +7,16 @@ using Combinatorics
 # Models
 export elowitz_2000, guan_2008
 # Simulation
-export generate_parameter_sets, equilibrate_ODEs, simulate_ODEs
+export generate_parameter_sets, equilibrate_ODEs, simulate_ODEs, calculate_simulation_times, calculate_oscillatory_status
 # Feature calculation
 export calculate_main_frequency, calculate_amplitude, is_ODE_oscillatory
 # Protein interaction network
 export protein_interaction_network, pin_parameters, pin_timescale, pin_parameter_sets
-export pin_equilibration_times, pin_simulation_times, pin_oscillatory_status, find_pin_oscillations
+export pin_equilibration_times, find_pin_oscillations
 export pin_hit_rate
 # Gene regulatory network
 export gene_regulatory_network, grn_parameters, grn_timescale, grn_parameter_sets
-export grn_equilibration_times, grn_simulation_times, grn_oscillatory_status, find_grn_oscillations
+export grn_equilibration_times, find_grn_oscillations
 # Network utilities
 export network_permutations, is_same_network, all_network_additions, unique_network_additions, unique_negative_feedback_networks
 

--- a/src/models.jl
+++ b/src/models.jl
@@ -18,6 +18,7 @@ elowitz_2000 = @reaction_network Elowitz_2000 begin
     μ₃, P₃ --> ∅
 end 
 
+
 """
     guan_2008
 

--- a/src/models.jl
+++ b/src/models.jl
@@ -18,7 +18,6 @@ elowitz_2000 = @reaction_network Elowitz_2000 begin
     μ₃, P₃ --> ∅
 end 
 
-
 """
     guan_2008
 

--- a/src/simulation.jl
+++ b/src/simulation.jl
@@ -1,4 +1,36 @@
 """
+    simulation_times(equilibration_data::Dict, equilibration_times::AbstractVector; simulation_time_multiplier=10)
+
+Calculates the simulation times for each parameter set in a model
+
+# Arguments (Required)
+- `equilibration_data::Dict`: Dictionary of equilibration data generated with [`equilibrate_ODEs`](@ref)
+- `equilibration_times::AbstractVector`: Array of equilibration times generated with [`equilibration_times`](@ref)
+
+# Arguments (Optional)
+- `simulation_time_multiplier::Real`: Factor by which the period (given by the estimated frequency from the equilibration) is multiplied by in order to calculate the final simulation time
+
+# Returns
+- `simulation_times::Array{Float64}`: Array of simulation times
+"""
+function simulation_times(equilibration_data::Dict, equilibration_times::AbstractVector; simulation_time_multiplier=10)
+    simulation_times = Array{Float64}(undef, 0)
+
+    for i in axes(equilibration_data["frequency"], 1)
+        freq = equilibration_data["frequency"][i]
+        if isnan(freq)
+            push!(simulation_times, equilibration_times[i])
+        else
+            push!(simulation_times, simulation_time_multiplier / freq )
+        end
+    end
+
+    return simulation_times
+end
+
+
+
+"""
     generate_parameter_sets(samples::Int, parameter_limits::AbstractVector, sampling_scales::AbstractVector, sampling_style::String="lhc")
 
 Creates an array of parameter sets within the limits provided in `parameter_limits` using either Latin Hypercube Sampling or Random Sampling. Each parameter can be sampled linearly or logarithmically.

--- a/src/simulation.jl
+++ b/src/simulation.jl
@@ -1,36 +1,4 @@
 """
-    simulation_times(equilibration_data::Dict, equilibration_times::AbstractVector; simulation_time_multiplier=10)
-
-Calculates the simulation times for each parameter set in a model
-
-# Arguments (Required)
-- `equilibration_data::Dict`: Dictionary of equilibration data generated with [`equilibrate_ODEs`](@ref)
-- `equilibration_times::AbstractVector`: Array of equilibration times generated with [`equilibration_times`](@ref)
-
-# Arguments (Optional)
-- `simulation_time_multiplier::Real`: Factor by which the period (given by the estimated frequency from the equilibration) is multiplied by in order to calculate the final simulation time
-
-# Returns
-- `simulation_times::Array{Float64}`: Array of simulation times
-"""
-function simulation_times(equilibration_data::Dict, equilibration_times::AbstractVector; simulation_time_multiplier=10)
-    simulation_times = Array{Float64}(undef, 0)
-
-    for i in axes(equilibration_data["frequency"], 1)
-        freq = equilibration_data["frequency"][i]
-        if isnan(freq)
-            push!(simulation_times, equilibration_times[i])
-        else
-            push!(simulation_times, simulation_time_multiplier / freq )
-        end
-    end
-
-    return simulation_times
-end
-
-
-
-"""
     generate_parameter_sets(samples::Int, parameter_limits::AbstractVector, sampling_scales::AbstractVector, sampling_style::String="lhc")
 
 Creates an array of parameter sets within the limits provided in `parameter_limits` using either Latin Hypercube Sampling or Random Sampling. Each parameter can be sampled linearly or logarithmically.
@@ -187,4 +155,60 @@ function simulate_ODEs(model::ReactionSystem, parameter_sets::AbstractArray, ini
                            "amplitude_data" => [simulation.u[i][3] for i=axes(simulation.u, 1)])
 
     return simulation_data
+end
+
+
+"""
+    calculate_simulation_times(equilibration_data::Dict, equilibration_times::AbstractVector; simulation_time_multiplier=10)
+
+Calculates the simulation times for each parameter set in a model
+
+# Arguments (Required)
+- `equilibration_data::Dict`: Dictionary of equilibration data generated with [`equilibrate_ODEs`](@ref)
+- `equilibration_times::AbstractVector`: Array of equilibration times generated with [`pin_equilibration_times`](@ref)
+
+# Arguments (Optional)
+- `simulation_time_multiplier::Real`: Factor by which the period (given by the estimated frequency from the equilibration) is multiplied by in order to calculate the final simulation time
+
+# Returns
+- `simulation_times::Array{Float64}`: Array of simulation times
+"""
+function calculate_simulation_times(equilibration_data::Dict, equilibration_times::AbstractVector; simulation_time_multiplier=10)
+    simulation_times = Array{Float64}(undef, 0)
+
+    for i in axes(equilibration_data["frequency"], 1)
+        freq = equilibration_data["frequency"][i]
+        if isnan(freq)
+            push!(simulation_times, equilibration_times[i])
+        else
+            push!(simulation_times, simulation_time_multiplier / freq )
+        end
+    end
+
+    return simulation_times
+end
+
+
+"""
+    calculate_oscillatory_status(simulation_data::Dict)
+
+Calculates the oscillatory status for each parameter set using the functionality of [`is_ODE_oscillatory`](@ref)
+
+# Arguments (Required)
+- `simulation_data::Dict`: Dictionary of simulation data generated with [`simulate_ODEs`](@ref)
+
+# Returns
+- `oscillatory_status::Array{Bool}`: Boolean array indicating whether each parameter set is oscillatory or not.
+"""
+function calculate_oscillatory_status(simulation_data::Dict)
+    oscillatory_status = Array{Bool}(undef, 0)
+
+    for i in axes(simulation_data["frequency_data"], 1)
+        freq = simulation_data["frequency_data"][i]
+        amp = simulation_data["amplitude_data"][i]
+        decision = is_ODE_oscillatory(freq, amp)
+        push!(oscillatory_status, decision)
+    end
+
+    return oscillatory_status
 end


### PR DESCRIPTION
Different versions for `simulation_times` (`oscillatory_status`) are refactored into a single function `calculate_simulation_times` (`calculate_oscillatory_status`).