### PR TITLE
Test addition to cycle

### DIFF
--- a/src/BiologicalOscillations.jl
+++ b/src/BiologicalOscillations.jl
@@ -18,7 +18,7 @@ export pin_hit_rate
 export gene_regulatory_network, grn_parameters, grn_timescale, grn_parameter_sets
 export grn_equilibration_times, find_grn_oscillations
 # Network utilities
-export network_permutations, is_same_network, is_same_set_of_networks, all_network_additions, unique_network_additions, unique_negative_feedback_networks
+export network_permutations, is_same_network, is_same_set_of_networks, all_network_additions, unique_network_additions, unique_negative_feedback_networks, unique_cycle_addition
 
 include("models.jl")
 include("simulation.jl")

--- a/src/BiologicalOscillations.jl
+++ b/src/BiologicalOscillations.jl
@@ -18,7 +18,7 @@ export pin_hit_rate
 export gene_regulatory_network, grn_parameters, grn_timescale, grn_parameter_sets
 export grn_equilibration_times, find_grn_oscillations
 # Network utilities
-export network_permutations, is_same_network, all_network_additions, unique_network_additions, unique_negative_feedback_networks
+export network_permutations, is_same_network, is_same_set_of_networks, all_network_additions, unique_network_additions, unique_negative_feedback_networks
 
 include("models.jl")
 include("simulation.jl")

--- a/src/network_utilities.jl
+++ b/src/network_utilities.jl
@@ -55,6 +55,47 @@ end
 
 
 """
+    is_same_set_of_networks(connectivity_vector1::AbstractVector, connectivity_vector2::AbstractVector)
+
+    Returns true if two sets have the same elements up to graph isomorphisms. False otherwise.
+
+# Arguments (Required)
+- `connectivity_vector1::AbstractVector`: Vector containing connectivity matrices
+- `connectivity_vector2::AbstractVector`: Vector containing connectivity matrices. Must have the same length as the first vector
+
+# Returns
+- `result::Bool`: True if two sets are equal. False otherwise. This may include the case where a set is degenerate
+"""
+function is_same_set_of_networks(connectivity_vector1::AbstractVector, connectivity_vector2::AbstractVector)
+    if length(connectivity_vector1) == length(connectivity_vector2)
+        # Check lengths
+        n = length(connectivity_vector1)
+        identity = zeros(Int64, n, n)
+    else
+        return false
+    end
+
+    for i in 1:n
+        for j in 1:n
+            if is_same_network(connectivity_vector1[i], connectivity_vector2[j])
+                identity[i, j] = 1
+            else
+                identity[i, j] = 0
+            end
+        end
+    end
+
+    if (all(sum(identity, dims=1) .== 1) & all(sum(identity, dims=2) .== 1))
+        # Check there is a 1-to-1 map between sets
+        return true
+    else
+        return false
+    end
+end
+
+
+
+"""
     all_network_additions(connectivity::AbstractMatrix, number_of_edges::Int64)
 
     Returns a vector containing all possible network additions of a network connectivity matrix.

--- a/test/network_utilities_tests.jl
+++ b/test/network_utilities_tests.jl
@@ -104,3 +104,39 @@ calculated_unique_6_nodes = unique_negative_feedback_networks(6)
 for network in true_unique_6_nodes
     @test any([is_same_network(network, calculated_network) for calculated_network in calculated_unique_6_nodes])
 end
+
+# Test the unique_network_additions and unique_cycle_addition functions
+t0 = [
+    0 -1 0 ;
+    0 0 -1 ;
+    -1 0 0 ;
+]
+t2 = [
+    0 1 0 ;
+    0 0 1 ;
+    -1 0 0 ;
+]
+s1 = [
+    0 -1 0 0 ;
+    0 0 -1 0 ;
+    0 0 0 -1 ;
+    1 0 0 0 ; 
+]
+s3 = [
+    0 1 0 0 ;
+    0 0 1 0 ;
+    0 0 0 1 ;
+    -1 0 0 0 ;
+]
+p2 = [
+    0 1 0 0 0 ;
+    0 0 1 0 0 ;
+    0 0 0 -1 0 ;
+    0 0 0 0 -1 ;
+    -1 0 0 0 0 ;
+]
+@test is_same_set_of_networks(unique_network_additions(t0, 1), unique_cycle_addition(t0))
+@test is_same_set_of_networks(unique_network_additions(t2, 1), unique_cycle_addition(t2))
+@test is_same_set_of_networks(unique_network_additions(s1, 1), unique_cycle_addition(s1))
+@test is_same_set_of_networks(unique_network_additions(s3, 1), unique_cycle_addition(s3))
+@test is_same_set_of_networks(unique_network_additions(p2, 1), unique_cycle_addition(p2))


### PR DESCRIPTION
I implemented an alternative algorithm to find all unique single-edge additions to a circular interaction network, `network_utilities/unique_cycle_addition`. Although the applicability of this algorithm is limited (it only applies to counting additions of a *single* edge to a *circular* base topology), it can be used to cross-check the existing function `network_utilities/unique_network_additions`.

It is expected that the following functions give the equal sets of the connectivity matrices:
```julia
connectivity_vector1 = unique_network_additions(connectivity, 1)
connectivity_vector2 = unique_cycle_addition(connectivity)
```

I also implemented a function to check if two vectors of connectivity matrices are equal:
```julia
is_same_set_of_networks(connectivity_vector1, connectivity_vector2)
```

Relevant tests are added as well.