### PR TITLE
Add function to find all cycles and their types in any networks

### DIFF
--- a/src/BiologicalOscillations.jl
+++ b/src/BiologicalOscillations.jl
@@ -22,7 +22,7 @@ export network_permutations, is_same_network, all_network_additions, unique_netw
 export is_directed_cycle_graph, is_same_set_of_networks, unique_cycle_addition
 export unique_negative_feedback_networks, count_inputs_by_coherence, is_negative_feedback_network
 export connectivity_to_binary, find_all_binary_circular_permutations, binary_to_connectivity
-export calculate_node_coherence
+export calculate_node_coherence, find_all_cycles_and_types
 # User input handling
 export is_valid_connectivity, connectivity_string_to_matrix
 # Default hyperparameters

--- a/src/network_utilities.jl
+++ b/src/network_utilities.jl
@@ -431,3 +431,48 @@ function unique_cycle_addition(connectivity::AbstractMatrix)
 
     return connectivity_vector
 end
+
+
+"""
+   find_all_cycles_and_types(connectivity::AbstractMatrix)
+
+   Returns a vector containing all unique cycles in a connectivity matrix. Each cycle is represented by a vector of nonduplicate node indices that define a cycle.a vector containing all unique cycles that can be found in a connectivity matrix. For example, if a Goodwin oscillator with a self-loop ([1 0 1; 1 0 0; 0 -1 0]) is given as an input, vectors [[1], [1, 2, 3]] and ["positive", "negative"] will be returned.
+
+# Arguments (Required)
+- `connectivity::AbstractMatrix`: Connectivity matrix of a network
+
+# Returns
+- `all_cycles::AbstractVector`: Vector containing vectors of node indices
+- `all_types::AbstractVector`: Vector containing types of respective cycles in `all_cycles`
+"""
+function find_all_cycles_and_types(connectivity::AbstractMatrix)
+    all_cycles = []
+    all_types = []
+    n = size(connectivity)[1]
+
+    # Following for statements iterate over all possible cycles in a complete directed graph (self-loops allowed) of the same size as the given graph
+    for cycle_length in 1:n
+        # Iterate over lengths of cycles
+        for c in combinations(1:n, cycle_length)
+            # With a given cycle length, iterate over possible combinations of nodes
+            for p in permutations(c[2:cycle_length])
+                # With a given combination of nodes, iterate over its all circular permutations
+
+                path_candidate = vcat(c[1], p, c[1])
+                # Note that the start (end) point of a cycle is repeated in the above list
+
+                index_start_node = path_candidate[1:end - 1]
+                index_end_node = path_candidate[2:end]
+
+                path_in_given_connectivity = connectivity[CartesianIndex.(index_end_node, index_start_node)]
+
+                if all(path_in_given_connectivity .!= 0)
+                    # When possible path exists in given connectivity
+                    push!(all_cycles, index_start_node)
+                    push!(all_types, (prod(path_in_given_connectivity) == 1 ? "positive" : "negative"))
+                end
+            end
+        end
+    end
+    return all_cycles, all_types
+end

--- a/test/network_utilities_tests.jl
+++ b/test/network_utilities_tests.jl
@@ -275,3 +275,29 @@ p2 = [0 0 0 0 -1; -1 0 0 0 0; 0 -1 0 0 0; 0 0 1 0 0; 0 0 0 1 0]
 @test is_same_set_of_networks(unique_network_additions(s1, 1), unique_cycle_addition(s1))
 @test is_same_set_of_networks(unique_network_additions(s3, 1), unique_cycle_addition(s3))
 @test is_same_set_of_networks(unique_network_additions(p2, 1), unique_cycle_addition(p2))
+
+# Test find_all_cycles_and_types. Note that the outputs of find_all_cycles_and_types are sorted by the cycle length (ascending order)
+connectivity = [0 0 0 1 -1;-1 0 0 0 0;0 -1 0 0 0;0 0 -1 0 0;0 0 0 -1 0]
+cycle, type = find_all_cycles_and_types(connectivity)
+@test cycle[1] == [1, 2, 3, 4]
+@test type[1] == "negative"
+
+connectivity = [1 0 0 0 -1;-1 0 0 0 0;0 -1 0 0 0;0 0 -1 0 0;0 0 0 -1 0]
+cycle, type = find_all_cycles_and_types(connectivity)
+@test cycle[1] == [1]
+@test type[1] == "positive"
+
+connectivity = [0 0 0 0 -1;-1 0 0 1 0;0 -1 0 0 0;0 0 -1 0 0;0 0 0 -1 0]
+cycle, type = find_all_cycles_and_types(connectivity)
+@test cycle[1] == [2, 3, 4]
+@test type[1] == "positive"
+
+connectivity = [0 0 0 0 -1;-1 0 0 0 0;0 -1 0 1 0;0 0 -1 0 0;0 0 0 -1 0]
+cycle, type = find_all_cycles_and_types(connectivity)
+@test cycle[1] == [3, 4]
+@test type[1] == "negative"
+
+connectivity = [0 0 0 0 -1;-1 0 0 0 0;0 -1 0 -1 0;0 0 -1 0 0;0 0 0 -1 0]
+cycle, type = find_all_cycles_and_types(connectivity)
+@test cycle[1] == [3, 4]
+@test type[1] == "positive"


### PR DESCRIPTION
This reopens PR #25 solving merge conflicts. The new function finds all cycles from a given connectivity matrix. The following is an example for a Goodwin oscillator with an additional positive feedback self-loop:
```julia
> find_all_cycles_and_types([1 0 1; 1 0 0; 0 -1 0])
(Any[[1], [1, 2, 3]], Any["positive", "negative"])
```
In the current implementation, the detected cycles are sorted in an ascending order by their lengths. The tests for the removed function `calculate_loop_length_and_type` is rewritten using the new function.