### PR TITLE
Solve Issue 31 - Random seed and output customization

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -25,6 +25,7 @@ ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 Peaks = "18e31ff7-3703-566c-8e60-38913d67486b"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 PyPlot = "d330b81b-6aea-500a-939a-2ce795aea3ee"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 

--- a/src/BiologicalOscillations.jl
+++ b/src/BiologicalOscillations.jl
@@ -7,7 +7,8 @@ using Combinatorics, Luxor, Images, FileIO, Random
 # Models
 export elowitz_2000, guan_2008
 # Simulation
-export generate_parameter_sets, equilibrate_ODEs, simulate_ODEs, calculate_simulation_times, calculate_oscillatory_status
+export generate_parameter_sets, equilibrate_ODEs, simulate_ODEs, calculate_simulation_times
+export calculate_oscillatory_status, generate_find_oscillations_output
 # Feature calculation
 export calculate_main_frequency, calculate_amplitude, is_ODE_oscillatory
 # Protein interaction network

--- a/src/BiologicalOscillations.jl
+++ b/src/BiologicalOscillations.jl
@@ -2,7 +2,7 @@ module BiologicalOscillations
 
 using Catalyst, DifferentialEquations, ModelingToolkit, Latexify
 using Statistics, DSP, Peaks, LatinHypercubeSampling, DataFrames
-using Combinatorics, Luxor, Images, FileIO
+using Combinatorics, Luxor, Images, FileIO, Random
 
 # Models
 export elowitz_2000, guan_2008
@@ -28,6 +28,7 @@ export is_valid_connectivity, connectivity_string_to_matrix
 # Default hyperparameters
 export DEFAULT_PIN_HYPERPARAMETERS, DEFAULT_PIN_PARAMETER_LIMITS, DEFAULT_PIN_SAMPLING_SCALES
 export DEFAULT_GRN_HYPERPARAMETERS, DEFAULT_GRN_PARAMETER_LIMITS, DEFAULT_GRN_SAMPLING_SCALES
+export DEFAULT_SIMULATION_OUTPUT
 # Visualization utilities
 export draw_connectivity
 

--- a/src/default_hyperparameters.jl
+++ b/src/default_hyperparameters.jl
@@ -91,6 +91,7 @@ DEFAULT_PIN_SAMPLING_SCALES = Dict(
 Default hyperparameters for the various algorithms involved in the find_pin_oscillations pipeline.
 """
 DEFAULT_PIN_HYPERPARAMETERS = Dict(
+    "random_seed" => 1234, # Random seed used to generate parameter sets.
     "initial_conditions" => NaN, # Set of initial conditions for `find_pin_oscillations`. Size should be equal to the number of samples indicated. If NaN, all species are initialized at 0.5.
     "equilibration_time_multiplier" => 10, # Multiplier applied to the slowest timescale to determine the equilibration time in `pin_equilibration_times`.
     "dimensionless_time" => true, # Whether to use dimensionless time in `pin_parameter_sets`. If true, the α parameter of the first node is set to 1 for all parameter sets. If false, no changes are made to the parameter sets.
@@ -146,6 +147,7 @@ DEFAULT_GRN_SAMPLING_SCALES = Dict(
 Default hyperparameters for the various algorithms involved in the find_grn_oscillations pipeline.
 """
 DEFAULT_GRN_HYPERPARAMETERS = Dict(
+    "random_seed" => 1234, # Random seed used to generate parameter sets.
     "initial_conditions" => NaN,  # Set of initial conditions for `find_grn_oscillations`. Size should be equal to the number of samples indicated. If NaN, all species are initialized at 10.
     "equilibration_time_multiplier" => 10, # Multiplier applied to the slowest timescale to determine the equilibration time in `grn_equilibration_times`.
     "dimensionless_time" => true, # Whether to use dimensionless time in `grn_parameter_sets`. If true, the α parameter of the first node is set to 1 and the first N (N = number of nodes) κ are set to 1 for all parameter sets. If false, no changes are made to the parameter sets.

--- a/src/default_hyperparameters.jl
+++ b/src/default_hyperparameters.jl
@@ -1,4 +1,63 @@
 """
+    DEFAULT_SIMULATION_OUTPUT::Dict{String, Any}
+
+Default selection of outputs for `find_pin_oscillations` and `find_grn_oscillations`.
+Each key specifies what can be saved from the following options:
+- "model": If value is set to true, saves the model that was simulated.
+- "hyperparameters": If value is set to true, saves the hyperparameters that were used in the simulation.
+- "parameter_sets": Saves the parameter sets that were simulated. A Dict is used to specify if the oscillatory and non-oscillatory parameter sets should be saved.
+- "equilibration_result": Saves data regarding the equilibration of the parameter sets. What data is saved is specified by the bool value in a Dict. For all the options see below.
+- "simulation_result": Saves data regarding the simulation of the parameter sets. What data is saved is specified by the bool value in a Dict. For all the options see below.
+
+The "equilibration_result" output can have the following options:
+- "parameter_index": Saves an identifier for each parameter set. Useful for indentifying parameter sets across result dataframes.
+- "equilibration_times": Times used for equilibrating each parameter set.
+- "final_velocity": Velocity of the final state after equilibration.
+- "final_state": Final state after equilibration. Creates one column for each species.
+- "frequency": Main frequency of the equilibration time-series. The value represents the average over all species.
+- "is_steady_state": Final decision on whether the parameter set is in steady state or not.
+
+The "simulation_result" output can have the following options:
+- "parameter_index": Saves an identifier for each parameter set. Useful for indentifying parameter sets across result dataframes.
+- "simulation_times": Times used for simulating each parameter set.
+- "final_state": Final state after simulation. Creates one column for each species.
+- "frequency": Main frequency of the simulation time-series. Creates one column for each species.
+- "fft_power": Power of the main frequency of the simulation time-series. Creates one column for each species.
+- "amplitude": Amplitude of the simulation time-series. Creates one column for each species.
+- "peak_variation": Coefficient of variation of the peak values of the simulation time-series. Creates one column for each species.
+- "trough_variation": Coefficient of variation of the trough values of the simulation time-series. Creates one column for each species.
+- "is_oscillatory": Final decision on whether the parameter set is oscillatory or not.
+"""
+DEFAULT_SIMULATION_OUTPUT = Dict(
+    "model" => true,
+    "hyperparameters" => true,
+    "parameter_sets" => Dict(
+        "oscillatory" => true,
+        "non_oscillatory" => true
+    ),
+    "equilibration_result" => Dict(
+        "parameter_index" => true,
+        "equilibration_times" => true,
+        "final_velocity" => true,
+        "final_state" => true,
+        "frequency" => true,
+        "is_steady_state" => true
+    ),
+    "simulation_result" => Dict(
+        "parameter_index" => true,
+        "simulation_times" => true,
+        "final_state" => true,
+        "frequency" => true,
+        "fft_power" => true,
+        "amplitude" => true,
+        "peak_variation" => true,
+        "trough_variation" => true,
+        "is_oscillatory" => true
+    )
+)
+
+
+"""
     DEFAULT_PIN_PARAMETER_LIMITS::Dict{String, Tuple{Float64, Float64}}
 
 Default parameter limits for the generation of pin parameter sets. Keys are the names of the parameters, values are tuples of the form (lower_limit, upper_limit).
@@ -46,7 +105,8 @@ DEFAULT_PIN_HYPERPARAMETERS = Dict(
     "simulation_time_multiplier" => 10, # Number of periods to simulate. Used in `calculate_simulation_times`
     "freq_variation_threshold" => 0.05, # Maximum tolerated variation in frequency between species in the solution to be declared oscillatory.
     "power_threshold" => 1e-7, # Minimum spectral power that the main peak has to have to be declared oscillatory.
-    "amp_variation_threshold" => 0.05 # Maximum tolerated value for peak/trough variation to be declared oscillatory.
+    "amp_variation_threshold" => 0.05, # Maximum tolerated value for peak/trough variation to be declared oscillatory.
+    "simulation_output" => DEFAULT_SIMULATION_OUTPUT,
 )
 
 
@@ -100,5 +160,6 @@ DEFAULT_GRN_HYPERPARAMETERS = Dict(
     "simulation_time_multiplier" => 10, # Number of periods to simulate. Used in `calculate_simulation_times`
     "freq_variation_threshold" => 0.05, # Maximum tolerated variation in frequency between species in the solution to be declared oscillatory.
     "power_threshold" => 1e-7, # Minimum spectral power that the main peak has to have to be declared oscillatory.
-    "amp_variation_threshold" => 0.05 # Maximum tolerated value for peak/trough variation to be declared oscillatory.
+    "amp_variation_threshold" => 0.05, # Maximum tolerated value for peak/trough variation to be declared oscillatory.
+    "simulation_output" => DEFAULT_SIMULATION_OUTPUT,
 )

--- a/src/default_hyperparameters.jl
+++ b/src/default_hyperparameters.jl
@@ -37,7 +37,7 @@ DEFAULT_SIMULATION_OUTPUT = Dict(
     ),
     "equilibration_result" => Dict(
         "parameter_index" => true,
-        "equilibration_times" => true,
+        "equilibration_time" => true,
         "final_velocity" => true,
         "final_state" => true,
         "frequency" => true,
@@ -45,7 +45,7 @@ DEFAULT_SIMULATION_OUTPUT = Dict(
     ),
     "simulation_result" => Dict(
         "parameter_index" => true,
-        "simulation_times" => true,
+        "simulation_time" => true,
         "final_state" => true,
         "frequency" => true,
         "fft_power" => true,

--- a/src/gene_regulatory_network.jl
+++ b/src/gene_regulatory_network.jl
@@ -302,59 +302,10 @@ function find_grn_oscillations(connectivity::AbstractMatrix, samples::Int; hyper
                                                       freq_variation_threshold=freq_variation_threshold,
                                                       power_threshold=power_threshold,
                                                       amp_variation_threshold=amp_variation_threshold)
-
-    # Create a dataframe with the parameter sets
-    parameter_map = paramsmap(model)
-    parameter_names = Array{String}(undef, length(parameter_map))
-    for (k, v) in parameter_map
-        parameter_names[v] = string(k)
-    end
-
-    # Create a dataframe with the equilibration result
-    equilibration_result = Dict(
-        "parameter_index" => collect(1:1:samples),
-        "equilibration_times" => equilibration_times,
-        "final_velocity" => equilibration_data["final_velocity"],
-        "frequency" => equilibration_data["frequency"],
-        "is_steady_state" => .!filter,)
-    final_state = mapreduce(permutedims, vcat, equilibration_data["final_state"])
-    for i=1:N
-        equilibration_result["final_state_$(i)"] = final_state[:,i]
-    end
-
-    # Create a dataframe with the simulation result
-    simulation_result = Dict(
-        "parameter_index" => collect(1:1:samples)[filter],
-        "simulation_times" => simulation_times[filter],
-        "is_oscillatory" => oscillatory_status,)
-    final_state = mapreduce(permutedims, vcat, simulation_data["final_state"])
-    for i=1:N
-        frequency = Array{Float64}(undef, 0)
-        power = Array{Float64}(undef, 0)
-        amplitude = Array{Float64}(undef, 0)
-        peak_variation = Array{Float64}(undef, 0)
-        trough_variation = Array{Float64}(undef, 0)
-        for j=1:sum(filter)
-            push!(frequency, simulation_data["frequency_data"][j]["frequency"][i])
-            push!(power, simulation_data["frequency_data"][j]["power"][i])
-            push!(amplitude, simulation_data["amplitude_data"][j]["amplitude"][i])
-            push!(peak_variation, simulation_data["amplitude_data"][j]["peak_variation"][i])
-            push!(trough_variation, simulation_data["amplitude_data"][j]["trough_variation"][i])
-        end
-        simulation_result["final_state_$(i)"] = final_state[:,i]
-        simulation_result["frequency_$(i)"] = frequency
-        simulation_result["fft_power_$(i)"] = power
-        simulation_result["amplitude_$(i)"] = amplitude
-        simulation_result["peak_variation_$(i)"] = peak_variation
-        simulation_result["trough_variation_$(i)"] = trough_variation
-    end
-
-    grn_result = Dict("model" => model,
-                      "parameter_sets" => DataFrame(parameter_sets, parameter_names),
-                      "equilibration_result" => DataFrame(equilibration_result),
-                      "simulation_result" => DataFrame(simulation_result),)
-
-    return grn_result
+    # Output
+    result = generate_find_oscillations_output(model, parameter_sets, equilibration_data, equilibration_times,
+                                               simulation_data, simulation_times, oscillatory_status, hyperparameters)
+    return result
 end
 
 

--- a/src/protein_interaction_network.jl
+++ b/src/protein_interaction_network.jl
@@ -289,59 +289,10 @@ function find_pin_oscillations(connectivity::AbstractMatrix, samples::Int; hyper
                                                       freq_variation_threshold=freq_variation_threshold, 
                                                       power_threshold=power_threshold, 
                                                       amp_variation_threshold=amp_variation_threshold)
-
-    # Create a dataframe with the parameter sets
-    parameter_map = paramsmap(model)
-    parameter_names = Array{String}(undef, length(parameter_map))
-    for (k, v) in parameter_map
-        parameter_names[v] = string(k)
-    end
-
-    # Create a dataframe with the equilibration result
-    equilibration_result = Dict(
-        "parameter_index" => collect(1:1:samples),
-        "equilibration_times" => equilibration_times,
-        "final_velocity" => equilibration_data["final_velocity"],
-        "frequency" => equilibration_data["frequency"],
-        "is_steady_state" => .!filter,)
-    final_state = mapreduce(permutedims, vcat, equilibration_data["final_state"])
-    for i=1:N
-        equilibration_result["final_state_$(i)"] = final_state[:,i]
-    end
-
-    # Create a dataframe with the simulation result
-    simulation_result = Dict(
-        "parameter_index" => collect(1:1:samples)[filter],
-        "simulation_times" => simulation_times[filter],
-        "is_oscillatory" => oscillatory_status,)
-    final_state = mapreduce(permutedims, vcat, simulation_data["final_state"])
-    for i=1:N
-        frequency = Array{Float64}(undef, 0)
-        power = Array{Float64}(undef, 0)
-        amplitude = Array{Float64}(undef, 0)
-        peak_variation = Array{Float64}(undef, 0)
-        trough_variation = Array{Float64}(undef, 0)
-        for j=1:sum(filter)
-            push!(frequency, simulation_data["frequency_data"][j]["frequency"][i])
-            push!(power, simulation_data["frequency_data"][j]["power"][i])
-            push!(amplitude, simulation_data["amplitude_data"][j]["amplitude"][i])
-            push!(peak_variation, simulation_data["amplitude_data"][j]["peak_variation"][i])
-            push!(trough_variation, simulation_data["amplitude_data"][j]["trough_variation"][i])
-        end
-        simulation_result["final_state_$(i)"] = final_state[:,i]
-        simulation_result["frequency_$(i)"] = frequency
-        simulation_result["fft_power_$(i)"] = power
-        simulation_result["amplitude_$(i)"] = amplitude
-        simulation_result["peak_variation_$(i)"] = peak_variation
-        simulation_result["trough_variation_$(i)"] = trough_variation
-    end
-
-    pin_result = Dict("model" => model,
-                      "parameter_sets" => DataFrame(parameter_sets, parameter_names),
-                      "equilibration_result" => DataFrame(equilibration_result),
-                      "simulation_result" => DataFrame(simulation_result),)
-
-    return pin_result
+    # Output
+    result = generate_find_oscillations_output(model, parameter_sets, equilibration_data, equilibration_times,
+                                               simulation_data, simulation_times, oscillatory_status, hyperparameters)
+    return result
 end
 
 

--- a/src/simulation.jl
+++ b/src/simulation.jl
@@ -7,6 +7,7 @@ Creates an array of parameter sets within the limits provided in `parameter_limi
 - `samples::Int``: Number of parameter sets to be generated
 - `parameter_limits::AbstractVector`: Array of tuples defining the lower and upper limits of each individual parameter in a model. The length of this array is used to calculate the number of parameters in each parameter set.
 - `sampling_scales::AbstractVector`: Array of strings containing the sampling scale for each individual parameter in a model. Accepted strings are "linear" and "log".
+- `random_seed::Int`: Seed for the random number generator.
 
 # Arguments (Optional)
 - `sampling_style::String`: Sampling style of the algorithm. Accepted strings are "lhc" and "random".
@@ -14,7 +15,8 @@ Creates an array of parameter sets within the limits provided in `parameter_limi
 # Returns
 - `parameter_sets::AbstractArray`: Array of parameter sets of length `samples`.
 """
-function generate_parameter_sets(samples::Int, parameter_limits::AbstractVector, sampling_scales::AbstractVector; sampling_style::String="lhc")
+function generate_parameter_sets(samples::Int, parameter_limits::AbstractVector, sampling_scales::AbstractVector, random_seed::Int; sampling_style::String="lhc")
+    Random.seed!(random_seed)
     number_of_parameters = length(parameter_limits)
     # Draw sample
     if lowercase(sampling_style) == "lhc"

--- a/src/simulation.jl
+++ b/src/simulation.jl
@@ -276,7 +276,9 @@ function generate_find_oscillations_output(model::ReactionSystem, parameter_sets
                 for i=1:length(parameter_map)
                     oscillatory_params_summary["$(parameter_names[i])"] = oscillatory_parameters[:,i]
                 end
-                result["parameter_sets"]["oscillatory"] = DataFrame(oscillatory_params_summary)
+                oscillatory_dataframe = DataFrame(oscillatory_params_summary)
+                column_order = vcat(["parameter_index"], parameter_names)
+                result["parameter_sets"]["oscillatory"] = select(oscillatory_dataframe, column_order)
             end
         end
         if haskey(hyperparameters["simulation_output"]["parameter_sets"], "non_oscillatory")
@@ -290,7 +292,9 @@ function generate_find_oscillations_output(model::ReactionSystem, parameter_sets
                 for i=1:length(parameter_map)
                     fixed_point_params_summary["$(parameter_names[i])"] = non_oscillatory_parameters[:,i]
                 end
-                result["parameter_sets"]["non_oscillatory"] = DataFrame(fixed_point_params_summary)
+                fixed_point_dataframe = DataFrame(fixed_point_params_summary)
+                column_order = vcat(["parameter_index"], parameter_names)
+                result["parameter_sets"]["non_oscillatory"] = select(fixed_point_dataframe, column_order)
             end
         end
     end

--- a/src/simulation.jl
+++ b/src/simulation.jl
@@ -266,18 +266,14 @@ function generate_find_oscillations_output(model::ReactionSystem, parameter_sets
         result["parameter_sets"] = Dict()
         if haskey(hyperparameters["simulation_output"]["parameter_sets"], "oscillatory") 
             if hyperparameters["simulation_output"]["parameter_sets"]["oscillatory"] == true
-                oscillatory_df = filter(row -> row["is_oscillatory"] == true, simulation_result)
-                oscillatory_idxs = oscillatory_df[!, "parameter_index"]
-                oscillatory_parameters = parameters[oscillatory_idxs, :]
+                oscillatory_parameters = parameters[oscillatory_status, :]
                 result["parameter_sets"]["oscillatory"] = DataFrame(oscillatory_parameters, 
                                                                     parameter_names)
             end
         end
         if haskey(hyperparameters["simulation_output"]["parameter_sets"], "non_oscillatory")
             if hyperparameters["simulation_output"]["parameter_sets"]["non_oscillatory"] == true
-                non_oscillatory_df = filter(row -> row["is_oscillatory"] == false, simulation_result)
-                non_oscillatory_idxs = non_oscillatory_df[!, "parameter_index"]
-                non_oscillatory_parameters = parameters[non_oscillatory_idxs, :]
+                non_oscillatory_parameters = parameters[.!oscillatory_status, :]
                 result["parameter_sets"]["non_oscillatory"] = DataFrame(non_oscillatory_parameters, 
                                                                         parameter_names)
             end

--- a/test/protein_interaction_network/pin_tests.jl
+++ b/test/protein_interaction_network/pin_tests.jl
@@ -156,3 +156,170 @@ connectivity_P0_6 = [0 0 0 0 -1; -1 0 0 0 0; 1 -1 0 0 0; 0 0 -1 0 0; 0 0 0 -1 0]
 P0_6_hit_rate = 0.059
 calculated_hit_rate = pin_hit_rate(connectivity_P0_6, samples; verbose=false)
 @test calculated_hit_rate ≈ P0_6_hit_rate rtol=0.3
+
+# Test that parameters from run and generated with a random seed are the same
+samples = 200
+random_seed = 4567
+connectivity_T0 = [0 0 -1;-1 0 0;0 -1 0]
+hyperparameters = DEFAULT_PIN_HYPERPARAMETERS
+hyperparameters["random_seed"] = random_seed
+result = find_pin_oscillations(connectivity_T0, samples; 
+                               hyperparameters=hyperparameters)
+
+oscillatory_params = result["parameter_sets"]["oscillatory"]
+fixed_point_params = result["parameter_sets"]["non_oscillatory"]
+all_params = vcat(oscillatory_params, fixed_point_params)
+all_params = sort!(all_params, :parameter_index)
+all_params = all_params[:, 2:end]
+column_order = [ "α[1]", "β[1]", "α[2]", "β[2]", "α[3]", "β[3]",
+                 "γ[1]", "κ[1]", "η[1]", "γ[2]", "κ[2]", "η[2]",
+                 "γ[3]", "κ[3]", "η[3]" ]
+all_params = select(all_params, column_order)
+
+model = result["model"]
+parameter_limits = hyperparameters["parameter_limits"]
+sampling_scales = hyperparameters["sampling_scales"]
+sampling_style = hyperparameters["sampling_style"]
+dimensionless_time = hyperparameters["dimensionless_time"]
+
+parameter_sets = pin_parameter_sets(model, samples, random_seed; 
+                                    dimensionless_time=dimensionless_time, 
+                                    parameter_limits=parameter_limits, 
+                                    sampling_scales=sampling_scales, 
+                                    sampling_style=sampling_style)
+
+for (idx, row) in enumerate(eachrow(all_params))
+    params_1 = parameter_sets[idx, :]
+    params_2 = collect(row)
+    @test params_1 == params_2
+end
+
+# Test that parameters are truly oscillatory and non-oscillatory
+# Values taken from run on 10/11/2023
+samples = 200
+random_seed = 4567
+connectivity_T0 = [0 0 -1;-1 0 0;0 -1 0]
+hyperparameters = DEFAULT_PIN_HYPERPARAMETERS
+hyperparameters["random_seed"] = random_seed
+solver = hyperparameters["solver"]
+result = find_pin_oscillations(connectivity_T0, samples; 
+                               hyperparameters=hyperparameters)
+model = result["model"]
+oscillatory_params = result["parameter_sets"]["oscillatory"]
+
+peak_number_found = zeros(2)
+for selected_idx in 1:2
+    parameter_index = oscillatory_params[selected_idx, 1]
+    final_states = select(result["simulation_result"], r"parameter_index|final_state_")
+    final_states = filter(row -> row["parameter_index"] == parameter_index, final_states)
+    initial_condition = collect(final_states[1, 1:end-1])
+    final_time = 10
+    parameters = collect(oscillatory_params[selected_idx, 2:end])
+    ode_problem = ODEProblem(model, initial_condition, 
+                            (0.0, final_time), parameters)
+    sol = solve(ode_problem, solver, saveat = final_time/5000)
+    df = DataFrame(t = sol.t, x = sol[1, :], y = sol[2, :], z = sol[3, :])
+    peak_num = size(findmaxima(df.x)[1], 1)
+    peak_number_found[selected_idx] = peak_num
+end
+
+expected_peaks = [13, 44]
+@test peak_number_found == expected_peaks
+
+# Test that parameters are truly non-oscillatory
+non_oscillatory_params = result["parameter_sets"]["non_oscillatory"]
+
+for selected_idx in 1:2
+    parameter_index = non_oscillatory_params[selected_idx, 1]
+    final_states = select(result["equilibration_result"], r"parameter_index|final_state_")
+    final_states = filter(row -> row["parameter_index"] == parameter_index, final_states)
+    final_condition = collect(final_states[1, 1:end-1])
+    initial_condition = 0.5 * ones(3)
+    final_time = 10
+    parameters = collect(non_oscillatory_params[selected_idx, 2:end])
+    ode_problem = ODEProblem(model, initial_condition, 
+                            (0.0, final_time), parameters)
+    sol = solve(ode_problem, solver, saveat = final_time/5000)
+    df = DataFrame(t = sol.t, x = sol[1, :], y = sol[2, :], z = sol[3, :])
+    final_state_simulation = collect(df[end, 2:end])
+    @test final_state_simulation ≈ final_condition rtol=1e-4
+end
+
+
+# Test that output can be customized
+samples = 200
+connectivity_T0 = [0 0 -1;-1 0 0;0 -1 0]
+hyperparameters = DEFAULT_PIN_HYPERPARAMETERS
+
+sim_output_config = Dict(
+    "model" => true,
+)
+hyperparameters["simulation_output"] = sim_output_config
+result = find_pin_oscillations(connectivity_T0, samples; 
+                               hyperparameters=hyperparameters)
+@test result["model"] isa ReactionSystem
+
+sim_output_config = Dict(
+    "hyperparameters" => true,
+)
+hyperparameters["simulation_output"] = sim_output_config
+result = find_pin_oscillations(connectivity_T0, samples; 
+                               hyperparameters=hyperparameters)
+@test result["hyperparameters"] isa Dict
+@test keys(result["hyperparameters"]) == keys(hyperparameters)
+for key in keys(hyperparameters)
+    # don't compare initial_conditions because it's NaN
+    if key == "initial_conditions"
+        continue
+    end
+    @test result["hyperparameters"][key] == hyperparameters[key]
+end
+
+sim_output_config = Dict(
+    "parameter_sets" => Dict(
+        "oscillatory" => true,
+        "non_oscillatory" => true
+    )
+)
+hyperparameters["simulation_output"] = sim_output_config
+result = find_pin_oscillations(connectivity_T0, samples; 
+                               hyperparameters=hyperparameters)
+@test result["parameter_sets"] isa Dict
+@test result["parameter_sets"]["oscillatory"] isa DataFrame
+@test result["parameter_sets"]["non_oscillatory"] isa DataFrame
+
+sim_output_config = Dict(
+    "equilibration_result" => Dict(
+        "parameter_index" => true,
+        "equilibration_time" => true,
+        "final_velocity" => true,
+        "final_state" => true,
+        "frequency" => true,
+        "is_steady_state" => true
+    )
+)
+hyperparameters["simulation_output"] = sim_output_config
+result = find_pin_oscillations(connectivity_T0, samples; 
+                               hyperparameters=hyperparameters)
+@test result["equilibration_result"] isa DataFrame
+@test size(result["equilibration_result"], 2) == 8
+
+sim_output_config = Dict(
+    "simulation_result" => Dict(
+        "parameter_index" => true,
+        "simulation_time" => true,
+        "final_state" => true,
+        "frequency" => true,
+        "fft_power" => true,
+        "amplitude" => true,
+        "peak_variation" => true,
+        "trough_variation" => true,
+        "is_oscillatory" => true
+    )
+)
+
+hyperparameters["simulation_output"] = sim_output_config
+result = find_pin_oscillations(connectivity_T0, samples; 
+                               hyperparameters=hyperparameters)
+@test result["simulation_result"] isa DataFrame
+@test size(result["simulation_result"], 2) == 21

--- a/test/protein_interaction_network/pin_tests.jl
+++ b/test/protein_interaction_network/pin_tests.jl
@@ -100,7 +100,7 @@ timescale = pin_timescale(α, β, γ)
 # Test `pin_parameter_sets`
 repressilator = protein_interaction_network([0 0 -1;-1 0 0;0 -1 0])
 samples = 10
-parameter_array = pin_parameter_sets(repressilator, samples)
+parameter_array = pin_parameter_sets(repressilator, samples, 123)
 n_parameters = length(parameters(repressilator))
 @test size(parameter_array) == (samples, n_parameters)
 @test all(parameter_array[:,1] .== 1.0)
@@ -108,7 +108,7 @@ n_parameters = length(parameters(repressilator))
 # Test `pin_equilibration_times`
 repressilator = protein_interaction_network([0 0 -1;-1 0 0;0 -1 0])
 samples = 10
-parameter_array = pin_parameter_sets(repressilator, samples)
+parameter_array = pin_parameter_sets(repressilator, samples, 123)
 equilibration_times = pin_equilibration_times(repressilator, parameter_array)
 @test size(equilibration_times) == (samples,)
 #TODO: Create a known solution and test that the equilibration times are correct

--- a/test/protein_interaction_network/pin_tests.jl
+++ b/test/protein_interaction_network/pin_tests.jl
@@ -1,4 +1,5 @@
 using BiologicalOscillations, Catalyst, ModelingToolkit, DifferentialEquations
+using DataFrames, Peaks
 
 # Test `protein_interaction_network`
 ## Error handling


### PR DESCRIPTION
This PR solves issue #31 by implementing two major changes:
- Parameter sets can be generated in a reproducible manner via a `random_seed` parameter added to `generate_parameter_sets` (and the functions that call it)
- The output of `find_pin_oscillations` and `find_grn_oscillations` can now be customized via `hyperparameters`. All the available outputs are encoded in the `DEFAULT_SIMULATION_OUTPUT` variable
```julia
DEFAULT_SIMULATION_OUTPUT = Dict(
    "model" => true,
    "hyperparameters" => true,
    "parameter_sets" => Dict(
        "oscillatory" => true,
        "non_oscillatory" => true
    ),
    "equilibration_result" => Dict(
        "parameter_index" => true,
        "equilibration_time" => true,
        "final_velocity" => true,
        "final_state" => true,
        "frequency" => true,
        "is_steady_state" => true
    ),
    "simulation_result" => Dict(
        "parameter_index" => true,
        "simulation_time" => true,
        "final_state" => true,
        "frequency" => true,
        "fft_power" => true,
        "amplitude" => true,
        "peak_variation" => true,
        "trough_variation" => true,
        "is_oscillatory" => true
    )
)
```
By specifying a dictionary with some of all of these keys one can customize the output. For example. If we simply want the simulation result (with some of its components), we can do the following:
```julia
samples = 200
connectivity_T0 = [0 0 -1;-1 0 0;0 -1 0]
hyperparameters = DEFAULT_PIN_HYPERPARAMETERS
sim_output_config = Dict(
    "simulation_result" => Dict(
        "parameter_index" => true,
        "final_state" => true,
        "frequency" => true,
        "amplitude" => true,
        "is_oscillatory" => true
    )
)

hyperparameters["simulation_output"] = sim_output_config
result = find_pin_oscillations(connectivity_T0, samples; 
                               hyperparameters=hyperparameters)
```