### PR TITLE
Add deepcopy to hyperparamters when copied

### DIFF
--- a/test/protein_interaction_network/pin_tests.jl
+++ b/test/protein_interaction_network/pin_tests.jl
@@ -162,7 +162,7 @@ calculated_hit_rate = pin_hit_rate(connectivity_P0_6, samples; verbose=false)
 samples = 200
 random_seed = 4567
 connectivity_T0 = [0 0 -1;-1 0 0;0 -1 0]
-hyperparameters = DEFAULT_PIN_HYPERPARAMETERS
+hyperparameters = deepcopy(DEFAULT_PIN_HYPERPARAMETERS)
 hyperparameters["random_seed"] = random_seed
 result = find_pin_oscillations(connectivity_T0, samples; 
                                hyperparameters=hyperparameters)
@@ -200,7 +200,7 @@ end
 samples = 200
 random_seed = 4567
 connectivity_T0 = [0 0 -1;-1 0 0;0 -1 0]
-hyperparameters = DEFAULT_PIN_HYPERPARAMETERS
+hyperparameters = deepcopy(DEFAULT_PIN_HYPERPARAMETERS)
 hyperparameters["random_seed"] = random_seed
 solver = hyperparameters["solver"]
 result = find_pin_oscillations(connectivity_T0, samples; 
@@ -250,7 +250,7 @@ end
 # Test that output can be customized
 samples = 200
 connectivity_T0 = [0 0 -1;-1 0 0;0 -1 0]
-hyperparameters = DEFAULT_PIN_HYPERPARAMETERS
+hyperparameters = deepcopy(DEFAULT_PIN_HYPERPARAMETERS)
 
 sim_output_config = Dict(
     "model" => true,


### PR DESCRIPTION
Closes #46. Adding `deepcopy()` when we want to customize hyperparameters starting from default ones