### PR TITLE
Add samples and nodes to simulation output

### DIFF
--- a/src/simulation.jl
+++ b/src/simulation.jl
@@ -247,6 +247,10 @@ function generate_find_oscillations_output(model::ReactionSystem, parameter_sets
     velocity = equilibration_data["final_velocity"]
     cutoff = 10 ^ mean(log10.(velocity))
     filter = velocity .> cutoff
+    # Samples
+    result["samples"] = samples
+    # Nodes
+    result["nodes"] = N
     # Model
     if haskey(hyperparameters["simulation_output"], "model")
         if hyperparameters["simulation_output"]["model"] == true

--- a/test/protein_interaction_network/pin_tests.jl
+++ b/test/protein_interaction_network/pin_tests.jl
@@ -324,3 +324,12 @@ result = find_pin_oscillations(connectivity_T0, samples;
                                hyperparameters=hyperparameters)
 @test result["simulation_result"] isa DataFrame
 @test size(result["simulation_result"], 2) == 21
+
+# Test correct number of samples and nodes on simulation_result
+samples = 10
+connectivity_T0 = [0 0 -1;-1 0 0;0 -1 0]
+result = find_pin_oscillations(connectivity_T0, samples)
+simulated_samples = result["samples"]
+simulated_nodes = result["nodes"]
+@test simulated_samples == samples
+@test simulated_nodes == 3


### PR DESCRIPTION
To facilitate post-processing I added the number of nodes and samples to the output of `find_pin_oscillations`.